### PR TITLE
Add basic search functionality to the backend

### DIFF
--- a/src/ggrc/fulltext/mysql.py
+++ b/src/ggrc/fulltext/mysql.py
@@ -136,8 +136,8 @@ class MysqlIndexer(SqlIndexer):
     type of object
     """
     # Note: This is an incomplete search syntax, much simpler than the
-    # Note: documented functionality: ~, !~, <, >, compound clauses (AND, OR)
-    # Note: are not implemented yet.
+    # documented functionality: ~, !~, <, >, compound clauses (AND, OR)
+    # are not implemented yet.
     if not terms:
       filters = self._default_search_fields()
     elif '!=' in terms:

--- a/src/ggrc/fulltext/recordbuilder.py
+++ b/src/ggrc/fulltext/recordbuilder.py
@@ -14,7 +14,16 @@ class RecordBuilder(object):
 
   def as_record(self, obj):
     # Defaults. These work when the record is not a custom attribute
-    properties = dict([(attr, getattr(obj, attr))
+    def compound_getattr(obj, attr):
+      """compound_getattr(assessment, 'contact.name') == assessment.contact.name
+
+      None will be returned also if assessment.contact is None.
+      """
+      for attr_part in attr.split('.'):
+        obj = getattr(obj, attr_part, None)
+      return obj
+
+    properties = dict([(attr, compound_getattr(obj, attr))
                        for attr in self._fulltext_attrs])
     record_id = obj.id
     record_type = obj.__class__.__name__

--- a/src/ggrc/fulltext/recordbuilder.py
+++ b/src/ggrc/fulltext/recordbuilder.py
@@ -12,18 +12,19 @@ class RecordBuilder(object):
     self._fulltext_attrs = AttributeInfo.gather_attrs(
         tgt_class, '_fulltext_attrs')
 
+  @staticmethod
+  def _compound_getattr(obj, attr):
+    """compound_getattr(assessment, 'contact.name') == assessment.contact.name
+
+    None will be returned also if assessment.contact is None.
+    """
+    for attr_part in attr.split('.'):
+      obj = getattr(obj, attr_part, None)
+    return obj
+
   def as_record(self, obj):
     # Defaults. These work when the record is not a custom attribute
-    def compound_getattr(obj, attr):
-      """compound_getattr(assessment, 'contact.name') == assessment.contact.name
-
-      None will be returned also if assessment.contact is None.
-      """
-      for attr_part in attr.split('.'):
-        obj = getattr(obj, attr_part, None)
-      return obj
-
-    properties = dict([(attr, compound_getattr(obj, attr))
+    properties = dict([(attr, self._compound_getattr(obj, attr))
                        for attr in self._fulltext_attrs])
     record_id = obj.id
     record_type = obj.__class__.__name__

--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -75,6 +75,13 @@ class Assessment(mixins_statusable.Statusable,
   ])
 
   # REST properties
+
+  # Enable fulltext indexing for all possible fields
+  _fulltext_attrs = ['title', 'slug', 'status', 'verified_date',
+                     'contact.name', 'secondary_contact.name', 'updated_at',
+                     'design', 'operationally', 'finished_date', 'url',
+                     'reference_url']
+
   _publish_attrs = [
       'design',
       'operationally',

--- a/test/integration/ggrc/services/test_common.py
+++ b/test/integration/ggrc/services/test_common.py
@@ -382,8 +382,8 @@ class TestResource(TestCase):
       self.mock_url(search='title!=baz'),
       headers=self.headers(),
     ))
-    self.assertListEqual(sorted([mock1, mock2], key=lambda json: json['id']),
-                         sorted(resp_models, key=lambda json: json['id']))
+    self.assertListEqual(sorted([mock1, mock2], key=lambda model: model['id']),
+                         sorted(resp_models, key=lambda model: model['id']))
 
   def test_collection_get_search_on_real_index(self):
     """Test collection GET method from common.py `__search`ing on real index"""

--- a/test/integration/ggrc/services/test_common.py
+++ b/test/integration/ggrc/services/test_common.py
@@ -319,10 +319,10 @@ class TestResource(TestCase):
       self.assertEqual((model['updated_at'], model['id']), expected)
 
   def test_collection_get_search(self):
-    """Test collection GET method from common.py with __search parameter."""
+    """Test collection GET method from common.py with __search parameter"""
 
     def make_mock_index(mock_model, property_list):
-      """Adds index records for listed properties of mock_model."""
+      """Add index records for listed properties of mock_model"""
       from ggrc.fulltext import get_indexer
       indexer = get_indexer()
       for prop in property_list:

--- a/test/unit/ggrc/fulltext/__init__.py
+++ b/test/unit/ggrc/fulltext/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: aleh_rymasheuski@epam.com
+# Maintained By: aleh_rymasheuski@epam.com

--- a/test/unit/ggrc/fulltext/test_recordbuilder.py
+++ b/test/unit/ggrc/fulltext/test_recordbuilder.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: aleh_rymasheuski@epam.com
+# Maintained By: aleh_rymasheuski@epam.com
+
+"""
+Test RecordBuilder logic
+"""
+
+# pylint: disable=protected-access
+
+import unittest
+
+import mock
+
+from ggrc.fulltext.recordbuilder import RecordBuilder
+
+
+class TestRecordBuilder(unittest.TestCase):
+  """Unit tests suite for RecordBuilder class"""
+
+  def test_compound_getattr(self):
+    """Test _compound_getattr parsing and application"""
+    obj = mock.MagicMock()
+    self.assertEqual(obj.foo,
+                     RecordBuilder._compound_getattr(obj, 'foo'))
+    self.assertEqual(obj.foo.bar,
+                     RecordBuilder._compound_getattr(obj, 'foo.bar'))
+    self.assertEqual(obj.foo.bar.baz,
+                     RecordBuilder._compound_getattr(obj, 'foo.bar.baz'))
+
+    obj.none = None
+    self.assertIsNone(RecordBuilder._compound_getattr(obj, 'none'))
+    self.assertIsNone(RecordBuilder._compound_getattr(obj, 'none.whatever'))
+
+  @mock.patch('ggrc.fulltext.recordbuilder.Record')
+  def test_as_record(self, record_mock):
+    """Test fulltext index record generation from object"""
+    obj_mock = mock.MagicMock(name='obj')
+    class_mock = mock.MagicMock(name='class', __bases__=[])
+    class_mock._fulltext_attrs = ['one_field', 'another_field',
+                                  'compound_field.sub']
+
+    builder = RecordBuilder(class_mock)
+    result = builder.as_record(obj_mock)
+
+    record_mock.assert_called_once_with(
+      obj_mock.id,
+      obj_mock.__class__.__name__,
+      obj_mock.context_id,
+      '',  # hardcoded empty parameter in recordbuilder.py
+      **{
+        'one_field': obj_mock.one_field,
+        'another_field': obj_mock.another_field,
+        'compound_field.sub': obj_mock.compound_field.sub,
+      }
+    )
+    self.assertEqual(record_mock(), result)


### PR DESCRIPTION
Add simple search features to the backend:
- `column = value` (exact match)
- `column != value` (exact non-match)
- `value` (any column contains `value`)

At the moment, we can only search in the fields that are indexed for full-text search.